### PR TITLE
Added additional error handling and support for DSS7

### DIFF
--- a/src/csdss_readlib_fullfile.py
+++ b/src/csdss_readlib_fullfile.py
@@ -223,6 +223,11 @@ def single_file_pull(dss_file, c_target_ts_list, scenario_name, s_flag):
     pathNames = np.array(list(pathNamesDict.values())[0])
 
     dfPaths = pd.DataFrame(pathNames, columns=["AllPaths"])
+
+    # is this is empty, the dss file is empty
+    if dfPaths.empty:
+        raise Exception(f'No pathnames found in {dss_file}')
+    
     # If the interpreter gives an error
     dfPaths[['blank1', 'A', 'B', 'C', 'D', 'E', 'F', 'blank2']] = \
             dfPaths['AllPaths'].str.split("/", expand=True)
@@ -282,6 +287,10 @@ def single_file_pull(dss_file, c_target_ts_list, scenario_name, s_flag):
     if not df_ts.empty:
         # move dates back by one day
         df_ts.index = df_ts.index + datetime.timedelta(days=-1)
+
+    # if the dataframe is empty, raise an error
+    else:
+        raise Exception(f'No fields from field list found in {dss_file}')
 
     return df_ts, c_target_ts_list_final, c_default_units
 

--- a/src/csdss_readlib_fullfile.py
+++ b/src/csdss_readlib_fullfile.py
@@ -227,7 +227,7 @@ def single_file_pull(dss_file, c_target_ts_list, scenario_name, s_flag):
     # is this is empty, the dss file is empty
     if dfPaths.empty:
         raise Exception(f'No pathnames found in {dss_file}')
-    
+
     # If the interpreter gives an error
     dfPaths[['blank1', 'A', 'B', 'C', 'D', 'E', 'F', 'blank2']] = \
             dfPaths['AllPaths'].str.split("/", expand=True)
@@ -263,7 +263,9 @@ def single_file_pull(dss_file, c_target_ts_list, scenario_name, s_flag):
 
             elif s_flag == 'salinity':
                 f_part = dfPaths[dfPaths[['A', 'B', 'C']].agg('/'.join, axis=1) == b_part]['F'].iloc[0]
-                e_part = '1MON'
+                # pull out the 1 month e part. (1MON for dss6 and 1Month for dss7)
+                e_part = dfPaths[dfPaths[['A', 'B', 'C']].agg('/'.join, axis=1) == b_part]['E'].values
+                e_part = [part for part in e_part if '1M' in part][0]
                 target_pathName = f'/{b_part}//{e_part}/{f_part}/'
 
 


### PR DESCRIPTION
Previously, CalView would error out in an unhelpful way if no timeseries could be pulled from a file. This would happen sometimes when using a DSS7 file or if none of the fields were in the given DSS file. DSS7 switched from '1MON' to '1Month' in the path names.

Added a fix for DSS7 files. Instead of using '1MON' for monthly values, the code will now use '1MON' or '1Month' as needed.

Added more meaningful errors when nothing was pulled. We still want it to fail, but now it fails in a meaningful way.